### PR TITLE
Refactor .map() and .amap()

### DIFF
--- a/aiolibs_executor/_executor.py
+++ b/aiolibs_executor/_executor.py
@@ -184,10 +184,7 @@ class Executor:
         for i in range(self._max_workers):
             task_name = self._task_name_prefix + f"_{i}"
             self._tasks.append(
-                loop.create_task(
-                    self._work(task_name),
-                    name=task_name,
-                )
+                loop.create_task(self._work(task_name), name=task_name)
             )
         return loop
 
@@ -236,9 +233,7 @@ class _WorkItem[R]:
             except AttributeError:
                 pass
             task = self.loop.create_task(
-                self.coro,
-                context=self.context,
-                name=name,
+                self.coro, context=self.context, name=name
             )
             fut.add_done_callback(_sync(task))
             ret = await task

--- a/aiolibs_executor/_executor.py
+++ b/aiolibs_executor/_executor.py
@@ -194,16 +194,6 @@ class Executor:
             )
         return loop
 
-    def _make_item[R](
-        self,
-        coro: Coroutine[Any, Any, R],
-        context: contextvars.Context | None,
-        loop: AbstractEventLoop | None,
-    ) -> "_WorkItem[R]":
-        if loop is None:
-            loop = self._lazy_init()
-        return _WorkItem(coro, loop, context)
-
     async def _process_items[R](
         self, work_items: list["_WorkItem[R]"]
     ) -> AsyncIterator[R]:

--- a/aiolibs_executor/_executor.py
+++ b/aiolibs_executor/_executor.py
@@ -160,9 +160,6 @@ class Executor:
                 del excs
 
     def _lazy_init(self) -> AbstractEventLoop:
-        # Lazy init exists for allowing Executor instantiation then there is no
-        # active event loop yet.
-        # .submit(), .map(), and .shutdown() all require running loop though.
         if self._shutdown:
             raise RuntimeError("cannot schedule new futures after shutdown")
         if self._loop is not None:


### PR DESCRIPTION
Remove redundant `.lazy_init()` call for each item.
Now the executor calls `.lazy_init()` once per `.map()` or `.amap()`.